### PR TITLE
Track Reddit API rate-limits

### DIFF
--- a/reddit.go
+++ b/reddit.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 
 	"github.com/thecsw/mira/v4/models"
@@ -38,6 +39,24 @@ func (c *Reddit) MiraRequest(method string, target string, payload map[string]st
 		return nil, err
 	}
 	defer response.Body.Close()
+
+	// Extract rate-limiting information from the response headers
+	if rateLimitUsed := response.Header.Get("X-Ratelimit-Used"); rateLimitUsed != "" {
+		if used, err := strconv.Atoi(rateLimitUsed); err == nil {
+			c.RateLimitUsed = used
+		}
+	}
+	if rateLimitRemaining := response.Header.Get("X-Ratelimit-Remaining"); rateLimitRemaining != "" {
+		if remaining, err := strconv.Atoi(rateLimitRemaining); err == nil {
+			c.RateLimitRemaining = remaining
+		}
+	}
+	if rateLimitReset := response.Header.Get("X-Ratelimit-Reset"); rateLimitReset != "" {
+		if reset, err := strconv.Atoi(rateLimitReset); err == nil {
+			c.RateLimitReset = reset
+		}
+	}
+
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(response.Body)
 	data := buf.Bytes()

--- a/reddit.go
+++ b/reddit.go
@@ -40,14 +40,14 @@ func (c *Reddit) MiraRequest(method string, target string, payload map[string]st
 	}
 	defer response.Body.Close()
 
-	// Extract rate-limiting information from the response headers
+	// Reddit returns integers for X-Ratelimit-Used and X-Ratelimit-Reset, but not for X-Ratelimit-Remaining
 	if rateLimitUsed := response.Header.Get("X-Ratelimit-Used"); rateLimitUsed != "" {
 		if used, err := strconv.Atoi(rateLimitUsed); err == nil {
 			c.RateLimitUsed = used
 		}
 	}
 	if rateLimitRemaining := response.Header.Get("X-Ratelimit-Remaining"); rateLimitRemaining != "" {
-		if remaining, err := strconv.Atoi(rateLimitRemaining); err == nil {
+		if remaining, err := strconv.ParseFloat(rateLimitRemaining, 64); err == nil {
 			c.RateLimitRemaining = remaining
 		}
 	}

--- a/reddit_struct.go
+++ b/reddit_struct.go
@@ -15,9 +15,9 @@ type Reddit struct {
 	Stream             Streaming
 	Values             RedditVals
 	Client             *http.Client
-	RateLimitUsed      int // The number of requests used in the current rate limit window
-	RateLimitRemaining int // The number of requests left to use in the current rate limit window
-	RateLimitReset     int // The number of seconds left in the current rate limit window
+	RateLimitUsed      int     // The number of requests used in the current rate limit window
+	RateLimitRemaining float64 // The number of requests left to use in the current rate limit window
+	RateLimitReset     int     // The number of seconds left in the current rate limit window
 }
 
 // Streaming is used for some durations on how frequently

--- a/reddit_struct.go
+++ b/reddit_struct.go
@@ -8,13 +8,16 @@ import (
 // Reddit is the main mira struct that practically
 // does everything
 type Reddit struct {
-	Token    string  `json:"access_token"`
-	Duration float64 `json:"expires_in"`
-	Creds    Credentials
-	Chain    chan *ChainVals
-	Stream   Streaming
-	Values   RedditVals
-	Client   *http.Client
+	Token              string  `json:"access_token"`
+	Duration           float64 `json:"expires_in"`
+	Creds              Credentials
+	Chain              chan *ChainVals
+	Stream             Streaming
+	Values             RedditVals
+	Client             *http.Client
+	RateLimitUsed      int // The number of requests used in the current rate limit window
+	RateLimitRemaining int // The number of requests left to use in the current rate limit window
+	RateLimitReset     int // The number of seconds left in the current rate limit window
 }
 
 // Streaming is used for some durations on how frequently


### PR DESCRIPTION
This should help those who wish to avoid sending unnecessary requests when close to or hitting the Reddit API rate limit. I used the headers Reddit documents here: [Reddit API Wiki](https://support.reddithelp.com/hc/en-us/articles/16160319875092-Reddit-Data-API-Wiki). The code handles missing or changed headers gracefully, so there isn't a risk of breaking if Reddit changes header names in the future.